### PR TITLE
[ISSUE RF-40]: Fix #112, Comms: no bcasts during GATT

### DIFF
--- a/src/app_heartbeat.c
+++ b/src/app_heartbeat.c
@@ -73,7 +73,7 @@ static rd_status_t send_adv (ri_comm_message_t * const p_msg)
             p_msg->repeat_count = repeat_count;
         }
 
-        err_code = rt_adv_send_data (p_msg);
+        err_code |= rt_adv_send_data (p_msg);
     }
     else
     {

--- a/src/main.h
+++ b/src/main.h
@@ -22,7 +22,7 @@
 
 // Submodule requirements
 #define RUUVI_BOARDS_REQ "0.8.1"
-#define RUUVI_DRIVERS_REQ "0.3.1"
+#define RUUVI_DRIVERS_REQ "0.3.2"
 #define RUUVI_ENDPOINTS_REQ "0.2.0"
 #define RUUVI_LIBRARIES_REQ "0.3.1"
 


### PR DESCRIPTION
Enabling 2 MBit/s GATT had a side-effect of enabling secondary PHY unnecessarily which prevented data being broadcast.  