### PR TITLE
Fix rc5 issues

### DIFF
--- a/src/app_comms.c
+++ b/src/app_comms.c
@@ -509,6 +509,7 @@ rd_status_t app_comms_ble_init (const bool secure)
     err_code |= dis_init (&dis, secure);
     err_code |= adv_init();
     err_code |= gatt_init (&dis, secure);
+    ri_radio_activity_callback_set (&app_sensor_vdd_measure_isr);
     return err_code;
 }
 

--- a/src/app_sensor.c
+++ b/src/app_sensor.c
@@ -242,11 +242,7 @@ void m_sensors_init (void)
 #endif
 }
 
-// Measure battery voltage after radio event
-#ifndef CEEDLING
-static
-#endif
-void on_radio_isr (const ri_radio_activity_evt_t evt)
+void app_sensor_vdd_measure_isr (const ri_radio_activity_evt_t evt)
 {
     rd_status_t err_code = RD_SUCCESS;
 
@@ -460,9 +456,6 @@ rd_status_t app_sensor_init (void)
                 m_sensors[ii]->handle = APP_SENSOR_HANDLE_UNUSED;
             }
         }
-
-        // Synchronize battery measurement to radio activity.
-        ri_radio_activity_callback_set (on_radio_isr);
     }
 
     return err_code;

--- a/src/app_sensor.h
+++ b/src/app_sensor.h
@@ -29,6 +29,7 @@
 #include "ruuvi_boards.h"
 #include "ruuvi_driver_error.h"
 #include "ruuvi_interface_communication.h"
+#include "ruuvi_interface_communication_radio.h"
 #include "ruuvi_task_sensor.h"
 
 #define APP_SENSOR_SELFTEST_RETRIES (5U) //!< Number of times to retry init on self-test fail.
@@ -214,6 +215,17 @@ rd_status_t app_sensor_handle (const ri_comm_xfer_fp_t ri_reply_fp,
                                const uint8_t * const raw_message,
                                const uint16_t data_len);
 
+
+/**
+ * @brief Synchronize VDD measurement to radio activity.
+ *
+ * Call this function before and after radio events to notify
+ * the device that ADC should be prepared to sample the droop voltage
+ * and to take the sample after heavy loading.
+ *
+ * @param[in] evt Type of next radio event, RI_RADIO_BEFORE ot RI_RADIO_AFTER
+ */
+void app_sensor_vdd_measure_isr (const ri_radio_activity_evt_t evt);
 
 #ifdef RUUVI_RUN_TESTS
 void app_sensor_ctx_get (rt_sensor_ctx_t *** m_sensors, size_t * num_sensors);

--- a/test/test_app_comms.c
+++ b/test/test_app_comms.c
@@ -167,6 +167,7 @@ static void app_comms_ble_init_Expect (const bool secure)
     test_dis_init (&ble_dis, secure);
     adv_init_Expect();
     gatt_init_Expect (&ble_dis, secure);
+    ri_radio_activity_callback_set_Expect (&app_sensor_vdd_measure_isr);
 }
 
 void test_app_comms_init_ok (void)

--- a/test/test_app_sensor.c
+++ b/test/test_app_sensor.c
@@ -69,7 +69,6 @@ void test_app_sensor_init_ok (void)
         rt_sensor_configure_ExpectWithArrayAndReturn (m_sensors[ii], 1, RD_SUCCESS);
     }
 
-    ri_radio_activity_callback_set_Expect (&on_radio_isr);
     err_code = app_sensor_init();
     TEST_ASSERT (RD_SUCCESS == err_code);
     m_sensors[0]->pwr_pin = pwr_0;
@@ -121,7 +120,6 @@ void test_app_sensor_init_first_time (void)
         rt_sensor_store_ExpectWithArrayAndReturn (m_sensors[ii], 1, RD_SUCCESS);
     }
 
-    ri_radio_activity_callback_set_Expect (&on_radio_isr);
     err_code = app_sensor_init();
     TEST_ASSERT (RD_SUCCESS == err_code);
 }
@@ -141,7 +139,6 @@ void test_app_sensor_init_not_found (void)
         rt_sensor_initialize_ExpectWithArrayAndReturn (m_sensors[ii], 1, RD_ERROR_NOT_FOUND);
     }
 
-    ri_radio_activity_callback_set_Expect (&on_radio_isr);
     err_code = app_sensor_init();
     TEST_ASSERT (RD_SUCCESS == err_code);
 }
@@ -166,7 +163,6 @@ void test_app_sensor_init_selftest_fail (void)
         } while (retries++ < APP_SENSOR_SELFTEST_RETRIES);
     }
 
-    ri_radio_activity_callback_set_Expect (&on_radio_isr);
     err_code = app_sensor_init();
     TEST_ASSERT (RD_ERROR_SELFTEST == err_code);
 }
@@ -242,7 +238,7 @@ void test_app_sensor_on_radio_before_ok (void)
     static uint64_t time = 1ULL;
     ri_rtc_millis_ExpectAndReturn (time);
     rt_adc_vdd_prepare_ExpectWithArrayAndReturn (&configuration, 1, RD_SUCCESS);
-    on_radio_isr (RI_RADIO_BEFORE);
+    app_sensor_vdd_measure_isr (RI_RADIO_BEFORE);
 }
 
 void test_app_sensor_on_radio_after_ok (void)
@@ -252,7 +248,7 @@ void test_app_sensor_on_radio_after_ok (void)
     rt_adc_is_init_ExpectAndReturn (true);
     ri_rtc_millis_ExpectAndReturn (time);
     rt_adc_vdd_sample_ExpectAndReturn (RD_SUCCESS);
-    on_radio_isr (RI_RADIO_AFTER);
+    app_sensor_vdd_measure_isr (RI_RADIO_AFTER);
 }
 
 /**


### PR DESCRIPTION
- Battery voltage not resampled after GATT connection / NFC read / button press due to reinitialization of radio dropping callbacks. 
- NFC data field labeled as "da" instead of "dt"
- Flash integration test not passing