### PR TITLE
Calling refactored GATT functions

### DIFF
--- a/src/app_comms.c
+++ b/src/app_comms.c
@@ -250,7 +250,7 @@ void handle_gatt_connected (void * p_data, uint16_t data_len)
 {
     rd_status_t err_code = RD_SUCCESS;
     // Disables advertising for GATT, does not kick current connetion out.
-    rt_gatt_disable ();
+    rt_gatt_adv_disable ();
     config_setup_on_this_conn ();
     RD_ERROR_CHECK (err_code, RD_SUCCESS);
 }
@@ -511,7 +511,7 @@ static rd_status_t gatt_init (const ri_comm_dis_init_t * const p_dis, const bool
     rt_gatt_set_on_connected_isr (&on_gatt_connected_isr);
     rt_gatt_set_on_disconn_isr (&on_gatt_disconnected_isr);
     rt_gatt_set_on_received_isr (&on_gatt_data_isr);
-    err_code |= rt_gatt_enable();
+    err_code |= rt_gatt_adv_enable();
 #endif
     return err_code;
 }

--- a/test/test_app_comms.c
+++ b/test/test_app_comms.c
@@ -137,7 +137,7 @@ static void gatt_init_Expect (ri_comm_dis_init_t * p_dis, const bool secure)
     rt_gatt_set_on_connected_isr_Expect (&on_gatt_connected_isr);
     rt_gatt_set_on_disconn_isr_Expect (&on_gatt_disconnected_isr);
     rt_gatt_set_on_received_isr_Expect (&on_gatt_data_isr);
-    rt_gatt_enable_ExpectAndReturn (RD_SUCCESS);
+    rt_gatt_adv_enable_ExpectAndReturn (RD_SUCCESS);
 #endif
 }
 
@@ -232,7 +232,7 @@ void test_app_comms_init_timer_fail (void)
 
 void test_handle_gatt_connected (void)
 {
-    rt_gatt_disable_ExpectAndReturn (RD_SUCCESS);
+    rt_gatt_adv_disable_ExpectAndReturn (RD_SUCCESS);
     handle_gatt_connected (NULL, 0);
     TEST_ASSERT (!m_config_enabled_on_next_conn);
 }


### PR DESCRIPTION
The GATT enable/disable functions are renamed in `ruuvi.drivers.c` to describe advertising feature. The renamed functions are called in `ruuvi.firmware.c` which requires fixing both in firmware and tests.