### PR TITLE
Update correct blog link to README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -13,7 +13,7 @@ Current git repository status:
 [![Technical Debt](https://sonarcloud.io/api/project_badges/measure?project=ruuvi_ruuvi.firmware.c&metric=sqale_index)](https://sonarcloud.io/dashboard?id=ruuvi_ruuvi.firmware.c)
 
 Ruuvi Firmware version 3. Built on top of Nordic SDK 15, uses both Ruuvi and external repositories as submodules.
-Under development, please follow [Ruuvi Blog](https://blog.ruuvi.com) for details. The project is in beta stage, no breaking changes are intented but will be done if absolutely necessary for some reason.  
+Under development, please follow [Ruuvi Blog](https://ruuvi.com/blog/) for details. The project is in beta stage, no breaking changes are intented but will be done if absolutely necessary for some reason.  
 
 # Setting up
 


### PR DESCRIPTION
This readme contains wrong/old linkt to the Ruuvi Blog, updated it to the one found from ruuvi.com