### PR TITLE
Add common file containing testing macros

### DIFF
--- a/testing.h
+++ b/testing.h
@@ -7,13 +7,13 @@
  * @brief A set of utilities to facilitate testing.
  */
 
-/* @brief TESTABLE_static: An inline macro to use with the Ceedling unit test.
+/* @brief TESTABLE_STATIC: An inline macro to use with the Ceedling unit test.
  * See https://www.design-reuse.com/articles/47812/embedded-software-unit-testing-with-ceedling.html
  *        for additional information.
  * and  ruuvi.drivers.c/test/interfaces/environmental/test_ruuvi_interface_shtcx.c
  *      ruuvi.drivers.c/src/tasks/ruuvi_task_led.c
  *
- * 1) example usage:    TESTABLE_static rd_status_t funky (const uint8_t * const astring, uint8_t along)
+ * 1) example usage:    TESTABLE_STATIC rd_status_t funky (const uint8_t * const astring, uint8_t along)
  *
  * When compiled for use for the Ceedling test this generates:
  *       rd_status_t funky (const uint8_t * const astring, uint8_t along)
@@ -21,7 +21,7 @@
  * When compiled normally:
  *        static rd_status_t funky (const uint8_t * const astring, uint8_t along)
  *
- * 2)example usage:    TESTABLE_static ri_timer_id_t m_timer;
+ * 2)example usage:    TESTABLE_STATIC ri_timer_id_t m_timer;
  *
  * When compiled for use with the Ceedling test this generates:
  *      ri_timer_id_t m_timer;
@@ -30,8 +30,8 @@
  *      static ri_timer_id_t m_timer;
  */
 #ifdef CEEDLING
-#   define TESTABLE_static          //  generate nothing
+#   define TESTABLE_STATIC          //  generate nothing
 #else
-#   define TESTABLE_static static   // generate: static
+#   define TESTABLE_STATIC static   // generate: static
 #endif
 


### PR DESCRIPTION
At present only contains TESTABLE_static for use with Ceedling unit testing

Replacing  3 lines:

#ifdef CEEDING
static
#endif
++++
As files are updated, replace those 3 lines with a prefix of TESTABLE_static (i.e. no need to change files just for this )